### PR TITLE
Update atmos-genesys version and remove logger dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.atmos-system/atmos-genesys "1.5"
+(defproject org.clojars.atmos-system/atmos-genesys "1.6"
   :description "The basis of all web projects using atmos tech"
   :url "https://github.com/AtmosSystem/Atmos-Genesys"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/atmos_genesys/services/core.clj
+++ b/src/atmos_genesys/services/core.clj
@@ -1,5 +1,3 @@
-(ns atmos-genesys.services.core
-  (:require
-    [atmos-genesys.services.logger]))
+(ns atmos-genesys.services.core)
 
 


### PR DESCRIPTION
The project version for atmos-genesys has been updated from 1.5 to 1.6 in the project.clj file. Additionally, the logger dependency has been removed from the services.core namespace in the core.clj file of the atmos-genesys service.