### PR TITLE
Restrict deploy to main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    if: contains('refs/heads/main', github.ref)
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This change introduces a condition to the deploy job, ensuring that it only runs if the workflow is triggered by a push to the `main` branch. This prevents unintended deployments from other branches, enhancing our deployment pipeline's reliability.